### PR TITLE
fixed url for cpc to ipc txt file

### DIFF
--- a/Development/process_cpcs/download_cpc_ipc.py
+++ b/Development/process_cpcs/download_cpc_ipc.py
@@ -145,7 +145,7 @@ def find_ipc_url():
     potential_links = []
     for link in tree.xpath('//a/@href'):
         print(link)
-        if (link.lstrip('.').lstrip("/").startswith("cpcConcordances/CPCtoIPCtxt")
+        if (link.lstrip('.').lstrip("/").startswith("cpc/concordances/cpc-ipc-concordance")
                 and link.endswith(".txt")):
             potential_links.append(link)
 


### PR DESCRIPTION
Changed the url path from cpcConcordances/CPCtoIPCtxt to cpc/concordances/cpc-ipc-concordance to reflect the change on the cooperativepatentclassification.org website